### PR TITLE
Use ilch_html_frontend and alwaysPurify(), FA 6 and more

### DIFF
--- a/upload/application/modules/kvticket/config/config.php
+++ b/upload/application/modules/kvticket/config/config.php
@@ -10,8 +10,8 @@ class Config extends \Ilch\Config\Install
 {
     public $config = [
         'key' => 'kvticket',
-        'version' => '1.4.0',
-        'icon_small' => 'fa-ticket',
+        'version' => '1.5.0',
+        'icon_small' => 'fa-solid fa-ticket',
         'author' => 'Veldscholten, Kevin',
         'languages' => [
             'de_DE' => [
@@ -23,8 +23,8 @@ class Config extends \Ilch\Config\Install
                 'description' => 'With this module, your users can report tickets/bugs.',
             ],
         ],
-        'ilchCore' => '2.1.15',
-        'phpVersion' => '5.6'
+        'ilchCore' => '2.1.52',
+        'phpVersion' => '7.3'
     ];
 
     public function install()
@@ -99,6 +99,9 @@ class Config extends \Ilch\Config\Install
                 }
                 // Remove no longer used datetime.
                 $this->db()->query('ALTER TABLE `[prefix]_kvticket` DROP COLUMN `datetime`;');
+            case "1.4.0":
+                // Update icon for FontAwesome 6.
+                $this->db()->query("UPDATE `[prefix]_modules` SET `icon_small` = '" . $this->config['icon_small'] . "' WHERE `key` = '" . $this->config['key'] . "';");
         }
     }
 }

--- a/upload/application/modules/kvticket/controllers/admin/Cat.php
+++ b/upload/application/modules/kvticket/controllers/admin/Cat.php
@@ -19,19 +19,19 @@ class Cat extends \Ilch\Controller\Admin
                 
                 'name' => 'manage',
                 'active' => false,
-                'icon' => 'fa fa-th-list',
+                'icon' => 'fa-solid fa-table-list',
                 'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index'])
             ],
             [
                 
                 'name' => 'cat',
                 'active' => false,
-                'icon' => 'fa fa-th-list',
+                'icon' => 'fa-solid fa-table-list',
                 'url' => $this->getLayout()->getUrl(['controller' => 'cat', 'action' => 'index']),
                 [
                     'name' => 'add',
                     'active' => false,
-                    'icon' => 'fa fa-plus-circle',
+                    'icon' => 'fa-solid fa-circle-plus',
                     'url' => $this->getLayout()->getUrl(['controller' => 'cat', 'action' => 'treat'])
                 ]
             ]

--- a/upload/application/modules/kvticket/controllers/admin/Index.php
+++ b/upload/application/modules/kvticket/controllers/admin/Index.php
@@ -20,12 +20,12 @@ class Index extends \Ilch\Controller\Admin
             [
                 'name' => 'manage',
                 'active' => false,
-                'icon' => 'fa fa-th-list',
+                'icon' => 'fa-solid fa-table-list',
                 'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'index']),
                 [
                     'name' => 'add',
                     'active' => false,
-                    'icon' => 'fa fa-plus-circle',
+                    'icon' => 'fa-solid fa-circle-plus',
                     'url' => $this->getLayout()->getUrl(['controller' => 'index', 'action' => 'treat'])
                 ]
             ],
@@ -33,7 +33,7 @@ class Index extends \Ilch\Controller\Admin
                 
                 'name' => 'cat',
                 'active' => false,
-                'icon' => 'fa fa-th-list',
+                'icon' => 'fa-solid fa-table-list',
                 'url' => $this->getLayout()->getUrl(['controller' => 'cat', 'action' => 'index'])
             ]
         ];

--- a/upload/application/modules/kvticket/models/Ticket.php
+++ b/upload/application/modules/kvticket/models/Ticket.php
@@ -189,7 +189,7 @@ class Ticket extends \Ilch\Model
     /**
      * Sets the Creator.
      *
-     * @param int $editor
+     * @param $creator
      * @return $this
      */
     public function setCreator($creator)

--- a/upload/application/modules/kvticket/views/admin/index/index.php
+++ b/upload/application/modules/kvticket/views/admin/index/index.php
@@ -45,9 +45,9 @@
                                 <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $ticket->getId()]) ?></td>
                                 <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $ticket->getId()]) ?></td>
                                 <td><?=$this->escape($ticket->getTitle()) ?></td>
-                                <td><?=($cat) ? $cat->getTitle() : '' ?></td>
-                                <td><?=($creator) ? $creator->getName() : '' ?></td>
-                                <td><?=($editor) ? $editor->getName() : '' ?></td>
+                                <td><?=($cat) ? $this->escape($cat->getTitle()) : '' ?></td>
+                                <td><?=($creator) ? $this->escape($creator->getName()) : '' ?></td>
+                                <td><?=($editor) ? $this->escape($editor->getName()) : '' ?></td>
                                 <td><?=$createdAt->format('d.m.Y H:i') ?></td>
                                 <td><?=$updatedAt->format('d.m.Y H:i') ?></td>
                             </tr>
@@ -97,9 +97,9 @@
                             <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $ticket->getId()]) ?></td>
                             <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $ticket->getId()]) ?></td>
                             <td><?=$this->escape($ticket->getTitle()) ?></td>
-                            <td><?=($cat) ? $cat->getTitle() : '' ?></td>
-                            <td><?=($creator) ? $creator->getName() : '' ?></td>
-                            <td><?=($editor) ? $editor->getName() : '' ?></td>
+                            <td><?=($cat) ? $this->escape($cat->getTitle()) : '' ?></td>
+                            <td><?=($creator) ? $this->escape($creator->getName()) : '' ?></td>
+                            <td><?=($editor) ? $this->escape($editor->getName()) : '' ?></td>
                             <td><?=$createdAt->format('d.m.Y H:i') ?></td>
                             <td><?=$updatedAt->format('d.m.Y H:i') ?></td>
                         </tr>
@@ -149,9 +149,9 @@
                             <td><?=$this->getEditIcon(['action' => 'treat', 'id' => $ticket->getId()]) ?></td>
                             <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $ticket->getId()]) ?></td>
                             <td><?=$this->escape($ticket->getTitle()) ?></td>
-                            <td><?=($cat) ? $cat->getTitle() : '' ?></td>
-                            <td><?=($creator) ? $creator->getName() : '' ?></td>
-                            <td><?=($editor) ? $editor->getName() : '' ?></td>
+                            <td><?=($cat) ? $this->escape($cat->getTitle()) : '' ?></td>
+                            <td><?=($creator) ? $this->escape($creator->getName()) : '' ?></td>
+                            <td><?=($editor) ? $this->escape($editor->getName()) : '' ?></td>
                             <td><?=$createdAt->format('d.m.Y H:i') ?></td>
                             <td><?=$updatedAt->format('d.m.Y H:i') ?></td>
                         </tr>
@@ -198,9 +198,9 @@
                             <td><?=$this->getDeleteCheckbox('check_tickets', $ticket->getId()) ?></td>
                             <td><?=$this->getDeleteIcon(['action' => 'del', 'id' => $ticket->getId()]) ?></td>
                             <td><?=$this->escape($ticket->getTitle()) ?></td>
-                            <td><?=($cat) ? $cat->getTitle() : '' ?></td>
-                            <td><?=($creator) ? $creator->getName() : '' ?></td>
-                            <td><?=($editor) ? $editor->getName() : '' ?></td>
+                            <td><?=($cat) ? $this->escape($cat->getTitle()) : '' ?></td>
+                            <td><?=($creator) ? $this->escape($creator->getName()) : '' ?></td>
+                            <td><?=($editor) ? $this->escape($editor->getName()) : '' ?></td>
                             <td><?=$createdAt->format('d.m.Y H:i') ?></td>
                             <td><?=$updatedAt->format('d.m.Y H:i') ?></td>
                         </tr>

--- a/upload/application/modules/kvticket/views/admin/index/treat.php
+++ b/upload/application/modules/kvticket/views/admin/index/treat.php
@@ -22,7 +22,7 @@
             <select class="form-control" id="cat" name="cat">
                 <option value="0" <?=(!$this->get('ticket')) ? 'selected' : '' ?>><?=$this->getTrans('noSelection') ?></option>
             <?php foreach ($this->get('cats') as $cat): ?>
-                <option value="<?=$cat->getId() ?>" <?=($this->get('ticket') && $this->get('ticket')->getCat() == $cat->getId()) ? 'selected' : '' ?>><?=$cat->getTitle() ?></option>
+                <option value="<?=$cat->getId() ?>" <?=($this->get('ticket') && $this->get('ticket')->getCat() == $cat->getId()) ? 'selected' : '' ?>><?=$this->escape($cat->getTitle()) ?></option>
             <?php endforeach; ?>
             </select>
         </div>

--- a/upload/application/modules/kvticket/views/index/index.php
+++ b/upload/application/modules/kvticket/views/index/index.php
@@ -24,37 +24,37 @@
                         <tr>
                             <th>
                                 <a href="<?=$this->getUrl(['column' => 'title', 'order' => $this->get('sort_order') == 'ASC'  ? 'desc' : 'asc']) ?>" title="<?=$this->getTrans('title') ?>">
-                                    <?=$this->getTrans('title') ?> <i class="fa fa-sort<?=$this->get('sort_column') == 'title' ? '-' . str_replace(['ASC','DESC'],['up','down'], $this->get('sort_order')) : ''; ?>"></i>
+                                    <?=$this->getTrans('title') ?> <i class="fa-solid fa-sort<?=$this->get('sort_column') == 'title' ? '-' . str_replace(['ASC','DESC'],['up','down'], $this->get('sort_order')) : ''; ?>"></i>
                                 </a>
                             </th>
                             <th>
                                 <a href="<?=$this->getUrl(['column' => 'cat', 'order' => $this->get('sort_order') == 'ASC'  ? 'desc' : 'asc']) ?>" title="<?=$this->getTrans('cat') ?>">
-                                    <?=$this->getTrans('cat') ?> <i class="fa fa-sort<?=$this->get('sort_column') == 'cat' ? '-' . str_replace(['ASC','DESC'], ['up','down'], $this->get('sort_order')) : ''; ?>"></i>
+                                    <?=$this->getTrans('cat') ?> <i class="fa-solid fa-sort<?=$this->get('sort_column') == 'cat' ? '-' . str_replace(['ASC','DESC'], ['up','down'], $this->get('sort_order')) : ''; ?>"></i>
                                 </a>
                             </th>
                             <th>
                                 <a href="<?=$this->getUrl(['column' => 'status', 'order' => $this->get('sort_order') == 'ASC'  ? 'desc' : 'asc']) ?>" title="<?=$this->getTrans('status') ?>">
-                                    <?=$this->getTrans('status') ?> <i class="fa fa-sort<?=$this->get('sort_column') == 'status' ? '-' . str_replace(['ASC','DESC'], ['up','down'], $this->get('sort_order')) : ''; ?>"></i>
+                                    <?=$this->getTrans('status') ?> <i class="fa-solid fa-sort<?=$this->get('sort_column') == 'status' ? '-' . str_replace(['ASC','DESC'], ['up','down'], $this->get('sort_order')) : ''; ?>"></i>
                                 </a>
                             </th>
                             <th>
                                 <a href="<?=$this->getUrl(['column' => 'creator', 'order' => $this->get('sort_order') == 'ASC'  ? 'desc' : 'asc']) ?>" title="<?=$this->getTrans('creator') ?>">
-                                    <?=$this->getTrans('creator') ?> <i class="fa fa-sort<?=$this->get('sort_column') == 'creator' ? '-' . str_replace(['ASC','DESC'], ['up','down'], $this->get('sort_order')) : ''; ?>"></i>
+                                    <?=$this->getTrans('creator') ?> <i class="fa-solid fa-sort<?=$this->get('sort_column') == 'creator' ? '-' . str_replace(['ASC','DESC'], ['up','down'], $this->get('sort_order')) : ''; ?>"></i>
                                 </a>
                             </th>
                             <th>
                                 <a href="<?=$this->getUrl(['column' => 'editor', 'order' => $this->get('sort_order') == 'ASC'  ? 'desc' : 'asc']) ?>" title="<?=$this->getTrans('editor') ?>">
-                                    <?=$this->getTrans('editor') ?> <i class="fa fa-sort<?=$this->get('sort_column') == 'editor' ? '-' . str_replace(['ASC','DESC'], ['up','down'], $this->get('sort_order')) : ''; ?>"></i>
+                                    <?=$this->getTrans('editor') ?> <i class="fa-solid fa-sort<?=$this->get('sort_column') == 'editor' ? '-' . str_replace(['ASC','DESC'], ['up','down'], $this->get('sort_order')) : ''; ?>"></i>
                                 </a>
                             </th>
                             <th>
                                 <a href="<?=$this->getUrl(['column' => 'created_at', 'order' => $this->get('sort_order') == 'ASC'  ? 'desc' : 'asc']) ?>" title="<?=$this->getTrans('createdAt') ?>">
-                                    <?=$this->getTrans('createdAt') ?> <i class="fa fa-sort<?=$this->get('sort_column') == 'created_at' ? '-' . str_replace(['ASC','DESC'], ['up','down'], $this->get('sort_order')) : ''; ?>"></i>
+                                    <?=$this->getTrans('createdAt') ?> <i class="fa-solid fa-sort<?=$this->get('sort_column') == 'created_at' ? '-' . str_replace(['ASC','DESC'], ['up','down'], $this->get('sort_order')) : ''; ?>"></i>
                                 </a>
                             </th>
                             <th>
                                 <a href="<?=$this->getUrl(['column' => 'updated_at', 'order' => $this->get('sort_order') == 'ASC'  ? 'desc' : 'asc']) ?>" title="<?=$this->getTrans('updatedAt') ?>">
-                                    <?=$this->getTrans('updatedAt') ?> <i class="fa fa-sort<?=$this->get('sort_column') == 'updated_at' ? '-' . str_replace(['ASC','DESC'], ['up','down'], $this->get('sort_order')) : ''; ?>"></i>
+                                    <?=$this->getTrans('updatedAt') ?> <i class="fa-solid fa-sort<?=$this->get('sort_column') == 'updated_at' ? '-' . str_replace(['ASC','DESC'], ['up','down'], $this->get('sort_order')) : ''; ?>"></i>
                                 </a>
                             </th>
                         </tr>
@@ -89,16 +89,16 @@
                                     </a>
                                 </td>
                                 <td<?=($this->get('sort_column') == 'cat' ? ' class="table-active"' : '') ?>>
-                                    <?=($cat ? $cat->getTitle() : '') ?>
+                                    <?=($cat ? $this->escape($cat->getTitle()) : '') ?>
                                 </td>
                                 <td<?=($this->get('sort_column') == 'status' ? ' class="table-active"' : '') ?>>
                                     <?=$ticketStatus ?>
                                 </td>
                                 <td<?=($this->get('sort_column') == 'creator' ? ' class="table-active"' : '') ?>>
-                                    <?=($creator) ? $creator->getName() : '' ?>
+                                    <?=($creator) ? $this->escape($creator->getName()) : '' ?>
                                 </td>
                                 <td<?=($this->get('sort_column') == 'editor' ? ' class="table-active"' : '') ?>>
-                                    <?=($editor) ? $editor->getName() : '' ?>
+                                    <?=($editor) ? $this->escape($editor->getName()) : '' ?>
                                 </td>
                                 <td<?=($this->get('sort_column') == 'created_at' ? ' class="table-active"' : '') ?>>
                                     <?=$createdAt->format('d.m.Y H:i') ?>

--- a/upload/application/modules/kvticket/views/index/new.php
+++ b/upload/application/modules/kvticket/views/index/new.php
@@ -9,7 +9,7 @@
             <select class="form-control" id="cat" name="cat">
                 <option value="0" selected><?=$this->getTrans('noSelection') ?></option>
             <?php foreach ($this->get('cats') as $cat): ?>
-                <option value="<?=$cat->getId() ?>"><?=$cat->getTitle() ?></option>
+                <option value="<?=$cat->getId() ?>"><?=$this->escape($cat->getTitle()) ?></option>
             <?php endforeach; ?>
             </select>
         </div>
@@ -34,7 +34,7 @@
             <textarea class="form-control ckeditor"
                       id="text"
                       name="text"
-                      toolbar="ilch_bbcode"
+                      toolbar="ilch_html_frontend"
                       rows="5"><?=$this->originalInput('text') ?></textarea>
         </div>
     </div>
@@ -60,7 +60,7 @@
                         document.getElementById('captcha').src='<?=$this->getUrl() ?>/application/libraries/Captcha/Captcha.php?'+Math.random();
                         document.getElementById('captcha-form').focus();"
                    id="change-image">
-                    <i class="fa fa-refresh"></i>
+                    <i class="fa-solid fa-arrows-rotate"></i>
                 </a>
             </span>
         </div>

--- a/upload/application/modules/kvticket/views/index/show.php
+++ b/upload/application/modules/kvticket/views/index/show.php
@@ -9,7 +9,7 @@ $createdAt = new \Ilch\Date($ticket->getCreatedAt());
 $updatedAt = new \Ilch\Date($ticket->getUpdatedAt());
 ?>
 
-<h1><?=$ticket->getTitle() ?></h1>
+<h1><?=$this->escape($ticket->getTitle()) ?></h1>
 <div class="row">
     <div class="col-lg-2">
         <b><?=$this->getTrans('status') ?></b>
@@ -31,7 +31,7 @@ $updatedAt = new \Ilch\Date($ticket->getUpdatedAt());
         <b><?=$this->getTrans('creator') ?></b>
     </div>
     <div class="col-lg-8">
-        <?=($creator) ? $creator->getName() : '' ?>
+        <?=($creator) ? $this->escape($creator->getName()) : '' ?>
     </div>
 </div>
 <div class="row">
@@ -39,7 +39,7 @@ $updatedAt = new \Ilch\Date($ticket->getUpdatedAt());
         <b><?=$this->getTrans('editor') ?></b>
     </div>
     <div class="col-lg-8">
-        <?=($editor) ? $editor->getName() : '' ?>
+        <?=($editor) ? $this->escape($editor->getName()) : '' ?>
     </div>
 </div>
 <br />
@@ -66,7 +66,7 @@ $updatedAt = new \Ilch\Date($ticket->getUpdatedAt());
         <b><?=$this->getTrans('cat') ?></b>
     </div>
     <div class="col-lg-8">
-        <?=$cat->getTitle() ?>
+        <?=$this->escape($cat->getTitle()) ?>
     </div>
 </div>
 <?php endif; ?>
@@ -76,7 +76,7 @@ $updatedAt = new \Ilch\Date($ticket->getUpdatedAt());
         <b><?=$this->getTrans('desc') ?></b>
     </div>
     <div class="col-lg-12">
-        <?=$ticket->getText() ?>
+        <?=$this->alwaysPurify($ticket->getText()) ?>
     </div>
 </div>
 <br />


### PR DESCRIPTION
- Use ilch_html_frontend and alwaysPurify()
- Updated icons for FontAwesome 6 
- Escaped various strings used in the views.

Ilch is transitioning to CKEditor 5, which no longer supports BBCode. So use CKEditor in HTML mode as preparation for the move.